### PR TITLE
don't use -static for AmberTools + fix sanity check

### DIFF
--- a/easybuild/easyblocks/a/amber.py
+++ b/easybuild/easyblocks/a/amber.py
@@ -140,7 +140,9 @@ class EB_Amber(ConfigureMake):
             else:
                 self.mpi_option = '-mpi'
 
-        common_configopts = [self.cfg['configopts'], '--no-updates', '-static', '-noX11']
+        common_configopts = [self.cfg['configopts'], '--no-updates', '-noX11']
+        if self.name == 'Amber':
+            common_configopts.append('-static')
 
         netcdfroot = get_software_root('netCDF')
         if netcdfroot:

--- a/easybuild/easyblocks/a/amber.py
+++ b/easybuild/easyblocks/a/amber.py
@@ -211,13 +211,18 @@ class EB_Amber(ConfigureMake):
 
     def sanity_check_step(self):
         """Custom sanity check for Amber."""
-        binaries = ['pmemd', 'sander', 'tleap']
-        if self.with_cuda:
-            binaries.append('pmemd.cuda')
-            if self.with_mpi:
-                binaries.append('pmemd.cuda.MPI')
+        binaries = ['sander', 'tleap']
+        if self.name == 'Amber':
+            binaries.append('pmemd')
+            if self.with_cuda:
+                binaries.append('pmemd.cuda')
+                if self.with_mpi:
+                    binaries.append('pmemd.cuda.MPI')
+
         if self.with_mpi:
-            binaries.extend(['pmemd.MPI', 'sander.MPI'])
+            binaries.extend(['sander.MPI'])
+            if self.name == 'Amber':
+                binaries.append('pmemd.MPI')
 
         custom_paths = {
             'files': [os.path.join(self.installdir, 'bin', binary) for binary in binaries],


### PR DESCRIPTION
update for https://github.com/easybuilders/easybuild-easyblocks/pull/1305 to fix issues with building `AmberTools` with `EB_Amber` easyblock that I ran into